### PR TITLE
Add change theme feature

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,13 +1,18 @@
 // import { useEffect, useRef, useState } from "react"
 // import { getMusicInfo } from "../api/musicGetter"
 import '../styles/music-component.css'
-import MenuIcon from '@mui/icons-material/Menu';
+import LightModeRoundedIcon from '@mui/icons-material/LightModeRounded';
+import DarkModeRoundedIcon from '@mui/icons-material/DarkModeRounded';
 import { buttonStyle } from "../themes/componentStyling";
+const Header = ({ theme, setTheme }) => {
 
-const Header = () => {
+
     return (
         <div>
-            <MenuIcon sx={buttonStyle}/>
+            {theme === 'light-theme' ?
+                <LightModeRoundedIcon onClick={() => setTheme('dark-theme')} sx={buttonStyle} /> :
+                <DarkModeRoundedIcon onClick={() => setTheme('light-theme')} sx={buttonStyle} />
+            }
         </div>
     )
 }

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -6,12 +6,16 @@ import DarkModeRoundedIcon from '@mui/icons-material/DarkModeRounded';
 import { buttonStyle } from "../themes/componentStyling";
 const Header = ({ theme, setTheme }) => {
 
+    const changeTheme = (newTheme) => {
+        setTheme(newTheme)
+        localStorage.setItem("theme", newTheme)
+    }
 
     return (
         <div>
             {theme === 'light-theme' ?
-                <LightModeRoundedIcon onClick={() => setTheme('dark-theme')} sx={buttonStyle} /> :
-                <DarkModeRoundedIcon onClick={() => setTheme('light-theme')} sx={buttonStyle} />
+                <LightModeRoundedIcon onClick={() => changeTheme('dark-theme')} sx={buttonStyle} /> :
+                <DarkModeRoundedIcon onClick={() => changeTheme('light-theme')} sx={buttonStyle} />
             }
         </div>
     )

--- a/src/routes/Home.jsx
+++ b/src/routes/Home.jsx
@@ -6,16 +6,17 @@ import ComingSoon from './ComingSoon'
 import { useEffect, useState } from 'react'
 
 const Home = () => {
-    const [theme, setTheme] = useState('dark-theme')
+    const [theme, setTheme] = useState(() => localStorage.getItem("theme") || 'light-theme')
 
     useEffect(() => {
         document.body.classList.remove('light-theme', 'dark-theme')
         document.body.classList.add(theme)
+        localStorage.setItem("theme", theme)
     }, [theme]);
 
     return (
         <>
-            <Header theme={theme} setTheme={setTheme}/>
+            <Header theme={theme} setTheme={setTheme} />
             <MusicComponent />
         </>
     )

--- a/src/routes/Home.jsx
+++ b/src/routes/Home.jsx
@@ -1,13 +1,21 @@
-import '../themes/light.css'
+import '../themes/theme.css'
 import '../index.css'
 import MusicComponent from '../components/MusicComponent'
 import Header from '../components/Header'
 import ComingSoon from './ComingSoon'
+import { useEffect, useState } from 'react'
 
 const Home = () => {
+    const [theme, setTheme] = useState('dark-theme')
+
+    useEffect(() => {
+        document.body.classList.remove('light-theme', 'dark-theme')
+        document.body.classList.add(theme)
+    }, [theme]);
+
     return (
         <>
-            <Header/>
+            <Header theme={theme} setTheme={setTheme}/>
             <MusicComponent />
         </>
     )

--- a/src/themes/dark.css
+++ b/src/themes/dark.css
@@ -1,9 +1,0 @@
-:root {
-    --web-background: #0b1215;
-    --text-color: #fafafa;
-    --text-color-hover: #999999;
-    --main-cta-color: #007f87;
-    --main-cta-color-hover: #006076;
-    --sub-cta-color: #9075d8;
-    --sub-cta-color-hover: #9f63c4;
-}

--- a/src/themes/light.css
+++ b/src/themes/light.css
@@ -1,9 +1,0 @@
-:root {
-    --web-background: #fafafa;
-    --text-color: #0b1215;
-    --text-color-hover: #0f181c;
-    --main-cta-color: #007f87;
-    --main-cta-color-hover: #006076;
-    --sub-cta-color: #9075d8;
-    --sub-cta-color-hover: #9f63c4;
-}

--- a/src/themes/theme.css
+++ b/src/themes/theme.css
@@ -1,0 +1,19 @@
+.light-theme {
+    --web-background: #fafafa;
+    --text-color: #0b1215;
+    --text-color-hover: #0f181c;
+    --main-cta-color: #007f87;
+    --main-cta-color-hover: #006076;
+    --sub-cta-color: #9075d8;
+    --sub-cta-color-hover: #9f63c4;
+}
+
+.dark-theme {
+    --web-background: #0b1215;
+    --text-color: #fafafa;
+    --text-color-hover: #999999;
+    --main-cta-color: #007f87;
+    --main-cta-color-hover: #006076;
+    --sub-cta-color: #9075d8;
+    --sub-cta-color-hover: #9f63c4;
+}


### PR DESCRIPTION
## Description
It's time to use color pallete that defined in #1 :D

### What's changed
Save theme detail to **localStorage** to save theme detail longer.
Store `/theme` detail in `/src` instead of `/public` due to Vite restriction.
Change `light.css` and `dark.css` to **css class**

### About theme button
Theme button show current theme in use: **Light theme** or **Dark theme**. When clicked, it will changed current theme to opposite theme and change button icon according to the new theme.


- In light theme, button look like this:
![image](https://github.com/user-attachments/assets/ca272e32-47a2-4188-b5e8-edb8b30a0e92)


- And in dark theme:
![image](https://github.com/user-attachments/assets/64e3c740-290b-4f4f-835d-377abcc5e9f0)

## Reason
- Currently, there is no theme change feature. 
- In dev environment, it only changed if change import in `Home.jsx`.

## Type of change
- [x] Add a new feature: New components, new pages, new features.
- [x] Refactored code to improve performance.